### PR TITLE
Remove bottle :unneeded per homebrew core deprecation

### DIFF
--- a/curlie.rb
+++ b/curlie.rb
@@ -3,7 +3,6 @@ class Curlie < Formula
   desc "The power of curl, the ease of use of httpie."
   homepage "https://curlie.io"
   version "1.6.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/rs/curlie/releases/download/v1.6.0/curlie_1.6.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fixes:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the rs/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/rs/homebrew-tap/curlie.rb:6
```
Context:
`bottle :unneeded` was deprecated in June of 2021: https://github.com/Homebrew/brew/pull/11239
